### PR TITLE
Add option to avoid guiding layout with todos

### DIFF
--- a/bin/visualize_packs
+++ b/bin/visualize_packs
@@ -29,6 +29,8 @@ OptionParser.new do |opt|
   opt.on('--roll-nested-into-parent-packs', "Don't show nested packs (not counting root). Connect edges to top-level pack instead") { |o| options.roll_nested_into_parent_packs = true }
   opt.on('--no-nesting-arrows', "Don't draw relationships between parents and nested packs") { |o| options.show_nested_relationships = false }
 
+  opt.on('--no-todos-guided-layout', "Avoid guiding the layout based on todos when hiding dependencies.") { |o| options.todos_guided_layout = false }
+
   opt.on('--remote-base-url=', "Link pack packs to a URL (affects graphviz SVG generation)") { |o| options.remote_base_url = o }
 
   opt.on_tail("-h", "--help", "Show this message") do

--- a/lib/graph.dot.erb
+++ b/lib/graph.dot.erb
@@ -88,7 +88,7 @@ digraph package_diagram {
         <%- todo_types.keys.each do |todo_type| -%>
           <%- if show_edge.call(package.name, todos_to_package) -%>
             "<%= package.name -%>" -> "<%= todos_to_package -%>"<%= todo_type == 'privacy' ? ':private' : '' -%> [ color=darkred style=dashed
-              <%- if options.show_dependencies -%>
+              <%- if options.show_dependencies || !options.todos_guided_layout -%>
                 constraint=false
               <%- end -%>
               # headlabel="<%= todo_type -%>"

--- a/lib/visualize_packs.rb
+++ b/lib/visualize_packs.rb
@@ -71,6 +71,7 @@ module VisualizePacks
       options.show_visibility ? nil : "hiding visibility",
       options.roll_nested_into_parent_packs ? "hiding nested packs" : nil,
       options.show_nested_relationships ? nil : "hiding nested relationships",
+      options.todos_guided_layout ? nil : "not guiding layout with todos",
       options.exclude_packs.empty? ? nil : "excluding pack#{options.exclude_packs.size > 1 ? 's' : ''}: #{limited_sentence(options.exclude_packs)}",
     ].compact.join(', ').strip
     main_title = "#{app_name}: #{focus_info}#{skipped_info != '' ? ' - ' + skipped_info : ''}"

--- a/lib/visualize_packs/options.rb
+++ b/lib/visualize_packs/options.rb
@@ -42,5 +42,7 @@ class Options < T::Struct
   prop :roll_nested_into_parent_packs, T::Boolean, default: false
   prop :show_nested_relationships, T::Boolean, default: true
 
+  prop :todos_guided_layout, T::Boolean, default: true
+
   prop :remote_base_url, T.nilable(String)
 end


### PR DESCRIPTION
Trying to solve https://github.com/rubyatscale/visualize_packs/issues/47.