### PR TITLE
replace all darwin platforms with universal platform

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,11 @@ GEM
     sorbet (0.5.10969)
       sorbet-static (= 0.5.10969)
     sorbet-runtime (0.5.10969)
+    sorbet-static (0.5.10969-universal-darwin-14)
+    sorbet-static (0.5.10969-universal-darwin-15)
+    sorbet-static (0.5.10969-universal-darwin-16)
+    sorbet-static (0.5.10969-universal-darwin-17)
+    sorbet-static (0.5.10969-universal-darwin-18)
     sorbet-static (0.5.10969-universal-darwin-19)
     sorbet-static (0.5.10969-universal-darwin-20)
     sorbet-static (0.5.10969-universal-darwin-21)
@@ -73,10 +78,7 @@ GEM
       yard (>= 0.9)
 
 PLATFORMS
-  arm64-darwin-20
-  arm64-darwin-21
-  arm64-darwin-22
-  x86_64-darwin-19
+  universal-darwin
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     visualize_packs (0.5.23)
+      bigdecimal
       packs-specification
       parse_packwerk (>= 0.20.0)
       sorbet-runtime
@@ -10,6 +11,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    bigdecimal (3.1.8)
     diff-lcs (1.5.0)
     netrc (0.11.0)
     packs-specification (0.0.10)

--- a/visualize_packs.gemspec
+++ b/visualize_packs.gemspec
@@ -23,8 +23,9 @@ Gem::Specification.new do |spec|
   # Specify which files should be added to the gem when it is released.
   spec.files = Dir['README.md', 'lib/**/*', "bin/**/*"]
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6'
+  spec.required_ruby_version = '>= 2.7'
 
+  spec.add_dependency 'bigdecimal'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency "rspec", "~> 3.12"
   spec.add_development_dependency 'sorbet'


### PR DESCRIPTION
- Adds the universal-darwin platform to hopefully stop the persistent sorbet-static bundler issues we run into
- Adds bigdecimal as an explicit dependency (it was [removed](https://bugs.ruby-lang.org/issues/19843) from the standard lib in 3.4)
- Drops 2.7 and head Ruby versions from matrix testing